### PR TITLE
Run fix-permissions to Match Upstream and test with pip install. Add lmodern.sty Req from knitr package. 

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -69,4 +69,6 @@ RUN R -e "devtools::install_github('ucbds-infra/ottr@stable')"
 
 USER $NB_USER
 
+RUN /usr/local/bin/fix-permissions
+
 RUN git lfs install

--- a/Containerfile
+++ b/Containerfile
@@ -67,7 +67,7 @@ RUN R -e "devtools::install_github('gbm-developers/gbm3')"
 
 RUN R -e "devtools::install_github('ucbds-infra/ottr@stable')"
 
-RUN /usr/local/bin/fix-permissions
+RUN /usr/local/bin/fix-permissions "${CONDA_DIR}"
 
 USER $NB_USER
 

--- a/Containerfile
+++ b/Containerfile
@@ -41,7 +41,8 @@ RUN apt update -qq && \
         cmake \
         libnlopt-dev \
         libboost-all-dev \
-        wget 
+        wget \
+        lmodern
 
 ## Install rstudio from source package
 RUN wget https://download1.rstudio.org/desktop/bionic/amd64/rstudio-${R_STUDIO_VERSION}-amd64.deb && \

--- a/Containerfile
+++ b/Containerfile
@@ -67,8 +67,8 @@ RUN R -e "devtools::install_github('gbm-developers/gbm3')"
 
 RUN R -e "devtools::install_github('ucbds-infra/ottr@stable')"
 
-USER $NB_USER
-
 RUN /usr/local/bin/fix-permissions
+
+USER $NB_USER
 
 RUN git lfs install

--- a/Containerfile
+++ b/Containerfile
@@ -67,7 +67,7 @@ RUN R -e "devtools::install_github('gbm-developers/gbm3')"
 
 RUN R -e "devtools::install_github('ucbds-infra/ottr@stable')"
 
-RUN /usr/local/bin/fix-permissions "${CONDA_DIR}"
+RUN /usr/local/bin/fix-permissions "${CONDA_DIR}" || true
 
 USER $NB_USER
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,7 @@ pipeline {
                         sh 'podman run -it --rm localhost/$IMAGE_NAME which rstudio'
                         sh 'podman run -it --rm localhost/$IMAGE_NAME R -q -e "getRversion() >= \\"4.1.3\\"" | tee /dev/stderr | grep -q "TRUE"'
                         sh 'podman run -it --rm localhost/$IMAGE_NAME R -e "library(\"usethis\");library(\"covr\");library(\"httr\");library(\"roxygen2\");library(\"rversions\");library(\"igraph\");library(\"imager\");library(\"patchwork\");library(\"littler\");library(\"docopt\");library(\"httr\");library(\"WDI\");library(\"faraway\");library(\"boot\");library(\"car\");library(\"pscl\");library(\"vcd\");library(\"stargazer\");library(\"effsize\");library(\"Rmisc\");library(\"tidyverse\");library(\"rstan\");library(\"brms\")"'
+                        sh 'podman run -it --rm localhost/$IMAGE_NAME pip install otter-grader'
                         sh 'podman run -d --name=$IMAGE_NAME --rm -p 8888:8888 localhost/$IMAGE_NAME start-notebook.sh --NotebookApp.token="jenkinstest"'
                         sh 'sleep 10 && curl -v http://localhost:8888/rstudio?token=jenkinstest 2>&1 | grep -P "HTTP\\S+\\s[1-3][0-9][0-9]\\s+[\\w\\s]+\\s*$"'
                         sh 'curl -v http://localhost:8888/lab?token=jenkinstest 2>&1 | grep -P "HTTP\\S+\\s200\\s+[\\w\\s]+\\s*$"'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@ pipeline {
                 stage('Test') {
                     steps {
                         sh 'podman run -it --rm localhost/$IMAGE_NAME which rstudio'
+                        sh 'podman run -it --rm localhost/$IMAGE_NAME find /usr/share -type f -name lmodern.sty'
                         sh 'podman run -it --rm localhost/$IMAGE_NAME R -q -e "getRversion() >= \\"4.1.3\\"" | tee /dev/stderr | grep -q "TRUE"'
                         sh 'podman run -it --rm localhost/$IMAGE_NAME R -e "library(\"usethis\");library(\"covr\");library(\"httr\");library(\"roxygen2\");library(\"rversions\");library(\"igraph\");library(\"imager\");library(\"patchwork\");library(\"littler\");library(\"docopt\");library(\"httr\");library(\"WDI\");library(\"faraway\");library(\"boot\");library(\"car\");library(\"pscl\");library(\"vcd\");library(\"stargazer\");library(\"effsize\");library(\"Rmisc\");library(\"tidyverse\");library(\"rstan\");library(\"brms\")"'
                         sh 'podman run -it --rm localhost/$IMAGE_NAME pip install otter-grader'


### PR DESCRIPTION
Runs `fix-permissions` at the end and tests that otter-grader can be installed as regular user, ephemerally.