### PR TITLE
Add -force-rm to podman build.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
             stages{
                 stage('Build') {
                     steps {
-                        sh 'podman build -t localhost/$IMAGE_NAME --rm --pull  --no-cache .'
+                        sh 'podman build -t localhost/$IMAGE_NAME --force-rm --pull  --no-cache .'
                      }
                 }
                 stage('Test') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
             stages{
                 stage('Build') {
                     steps {
-                        sh 'podman build -t localhost/$IMAGE_NAME --pull  --no-cache .'
+                        sh 'podman build -t localhost/$IMAGE_NAME --rm --pull  --no-cache .'
                      }
                 }
                 stage('Test') {


### PR DESCRIPTION
Removed intermediate builds.  Since we always build with --no-cache, all these do is clog up the filesystem on the build servers.