### PR TITLE
Let pip manage matplotlib for R since conda is volatile.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -57,8 +57,10 @@ RUN R -e "dotR <- file.path(Sys.getenv('HOME'), '.R'); if(!file.exists(dotR)){ d
 RUN pip install nbgitpuller && \
     jupyter serverextension enable --py nbgitpuller --sys-prefix 
     
-RUN mamba install -y -c conda-forge --freeze-installed jupyter-server-proxy jupyter-rsession-proxy udunits2 imagemagick pandas numpy matplotlib && \
+RUN mamba install -y -c conda-forge --freeze-installed jupyter-server-proxy jupyter-rsession-proxy udunits2 imagemagick pandas numpy && \
     mamba clean --all
+
+RUN pip install matplotlib
 
 RUN R -e "install.packages(c('usethis','covr','httr','roxygen2','rversions','igraph','imager','patchwork','littler', 'docopt','httr','WDI', 'faraway', 'boot', 'car', 'pscl', 'vcd', 'stargazer', 'effsize', 'Rmisc', 'tidyverse', 'brms', 'rstan'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
 


### PR DESCRIPTION
mamba doesn't seem to be able to install matplotlib with `--freeze-installed` at the moment and without it, it either upgrades or downgrades R for now obviously good reason.  Letting pip install matplotlib seems to be more sane for R.