### PR TITLE
Update download links for RStudio using current versions of RStudio/Ubuntu

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -45,7 +45,7 @@ RUN apt update -qq && \
         lmodern
 
 ## Install rstudio from source package
-RUN wget https://download1.rstudio.org/element/jammy/amd64/rstudio-${R_STUDIO_VERSION}-amd64.deb && \
+RUN wget https://download1.rstudio.org/electron/jammy/amd64/rstudio-${R_STUDIO_VERSION}-amd64.deb && \
     wget https://download2.rstudio.org/server/jammy/amd64/rstudio-server-${R_STUDIO_VERSION}-amd64.deb && \
     apt install ./rstudio*.deb -yq && apt-get clean && rm -f ./rstudio*.deb && \
     apt-get clean 

--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,7 @@ LABEL maintainer="LSIT Systems <lsitops@ucsb.edu>"
 
 USER root
 
-ENV R_STUDIO_VERSION 2022.07.2-576
+ENV R_STUDIO_VERSION 2022.12.0-353
 
 RUN apt update -qq && \
     apt install software-properties-common -y && \
@@ -45,8 +45,8 @@ RUN apt update -qq && \
         lmodern
 
 ## Install rstudio from source package
-RUN wget https://download1.rstudio.org/desktop/bionic/amd64/rstudio-${R_STUDIO_VERSION}-amd64.deb && \
-    wget https://download2.rstudio.org/server/bionic/amd64/rstudio-server-${R_STUDIO_VERSION}-amd64.deb && \
+RUN wget https://download1.rstudio.org/element/jammy/amd64/rstudio-${R_STUDIO_VERSION}-amd64.deb && \
+    wget https://download2.rstudio.org/server/jammy/amd64/rstudio-server-${R_STUDIO_VERSION}-amd64.deb && \
     apt install ./rstudio*.deb -yq && apt-get clean && rm -f ./rstudio*.deb && \
     apt-get clean 
 


### PR DESCRIPTION
3 changes:
* Bump RStudio to version 2022.12.0-353
* Update .deb download location for client package (upstream change)
* Update Ubuntu packages to use jammy instead of bionic (whoopsie)