### PR TITLE
Add Jenkins node to build output for quicker lookups.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
             stages{
                 stage('Build') {
                     steps {
+			sh 'echo "NODE_NAME = ${env.NODE_NAME}"'
                         sh 'podman build -t localhost/$IMAGE_NAME --pull --force-rm --no-cache .'
                      }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
             stages{
                 stage('Build') {
                     steps {
-			sh 'echo "NODE_NAME = ${env.NODE_NAME}"'
+			echo "NODE_NAME = ${env.NODE_NAME}"
                         sh 'podman build -t localhost/$IMAGE_NAME --pull --force-rm --no-cache .'
                      }
                 }


### PR DESCRIPTION
This should make the node name show up in the build logs and in Blue Ocean without needing to go to Classic View and the Build Steps.  This could make it quicker to identify nodes that have ran out of space, etc.  If this works, I'll add it to the jupyter base, image templates, etc., as well.