### PR TITLE
Bump Versions and Source

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/jupyter/r-notebook:r-4.3.2
+FROM quay.io/jupyter/r-notebook:r-4.3.3
 
 LABEL maintainer="LSIT Systems <lsitops@ucsb.edu>"
 

--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,7 @@ LABEL maintainer="LSIT Systems <lsitops@ucsb.edu>"
 
 USER root
 
-ENV R_STUDIO_VERSION 2023.12.0-369
+ENV R_STUDIO_VERSION 2024.04.0-735
 
 RUN apt update -qq && \
     apt install software-properties-common -y && \

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM jupyter/r-notebook:r-4.3.1
+FROM quay.io/jupyter/r-notebook:r-4.3.2
 
 LABEL maintainer="LSIT Systems <lsitops@ucsb.edu>"
 

--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,7 @@ LABEL maintainer="LSIT Systems <lsitops@ucsb.edu>"
 
 USER root
 
-ENV R_STUDIO_VERSION 2023.06.1-524
+ENV R_STUDIO_VERSION 2023.12.0-369
 
 RUN apt update -qq && \
     apt install software-properties-common -y && \


### PR DESCRIPTION
Upstream images are stored at quay.io. We're behind on some of our major versions as a result. Bumping this to latest versions of R and RStudio. 