### PR TITLE
Remove Stale PPA

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,7 +8,6 @@ ENV R_STUDIO_VERSION 2024.04.2-764
 
 RUN apt update -qq && \
     apt install software-properties-common -y && \
-    add-apt-repository ppa:nrbrtx/libssl1 && \
     apt update -qq && \
     apt upgrade -y && \
     apt install -y \


### PR DESCRIPTION
It was used to provide libssl1. Since it's not supported in noble, and was a requirement for RStudio 21, but seems like it's no longer required for 24, we're removing it. 