### PR TITLE
Fix home perms

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -78,7 +78,7 @@ RUN R -e "devtools::install_github('ucbds-infra/ottr@stable')"
 
 RUN /usr/local/bin/fix-permissions "${CONDA_DIR}" || true
 
-RUN /usr/local/bin/fix-permissions "${CONDA_DIR}" || true
+RUN chown -R jovyan:users /home/jovyan
 
 USER $NB_USER
 


### PR DESCRIPTION
Fixes this situation

```
podman run --rm -it --entrypoint=bash ucsb/jupyter-base:latest 
bash: /home/jovyan/.bashrc: Permission denied
jovyan@affdb1d08dc1:~$ ls -l
ls: cannot open directory '.': Permission denied
jovyan@affdb1d08dc1:~$ pwd
/home/jovyan
```